### PR TITLE
119 task add the push on the epitechs repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,7 @@ jobs:
   push_to_mirror:
     needs: [docker-compose-validation, check_the_repository]
     runs-on: ubuntu-latest
+    if: needs.check_the_repository.outputs.same_repository == 'false'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to optimize which jobs run based on changes in specific directories, introduces a repository mirroring step, and adds logic to check if the workflow is running in the main or mirror repository. The main improvements are better efficiency in CI runs and automated mirroring to a secondary repository.

**Workflow optimization and selective job execution:**

* Added a `check-changes` job using the `dorny/paths-filter` action to detect changes in the `backend`, `frontend`, and `mobile` directories, allowing subsequent jobs to run only if relevant files have changed.
* Modified the `backend-ci`, `frontend-ci`, and `mobile-ci` jobs to depend on `check-changes` and only execute if there are changes in their respective directories or if the workflow is manually triggered. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR15-R60) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR143-R144) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR185-R186)
* Updated the `docker-compose-validation` job to only run if any of the main project areas (`backend`, `frontend`, `mobile`) have changes, further reducing unnecessary CI runs.

**Repository mirroring and validation:**

* Introduced a `check_the_repository` job to compare the current repository with a mirror repository, providing notifications and outputs for further conditional logic.
* Added a `push_to_mirror` job that runs after successful validation, using the `pixta-dev/repository-mirroring-action` to push all changes to the mirror repository, automating repository synchronization.